### PR TITLE
Update checkout action version to v6

### DIFF
--- a/.github/workflows/update-install-sh.yml
+++ b/.github/workflows/update-install-sh.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Run script
         run: |
           set -e -x


### PR DESCRIPTION
To fix the CI annotation warning: https://github.com/AdguardTeam/AdGuardCLI/actions/runs/23327500443/job/67851748246#step:7:2